### PR TITLE
Fix create_github_release script

### DIFF
--- a/scripts/versioning/create_github_release.rb
+++ b/scripts/versioning/create_github_release.rb
@@ -22,7 +22,7 @@ def create_github_release(repo_owner, repo_name, access_token, tag_name, release
   response = Faraday.post(github_api_url, release_data.to_json, headers)
 
   if response.status == 201
-    puts "Release URL: #{JSON.parse(response.body)
+    puts "Release URL: #{JSON.parse(response.body)}"
     release_url = JSON.parse(response.body)['upload_url'].gsub("{?name,label}", "?name=#{File.basename(file_path)}")
     if file_path
       upload_asset(release_url, file_path, access_token)


### PR DESCRIPTION
<!-- Commit message: This repository uses a commit message convention https://www.conventionalcommits.org/en/v1.0.0/ set the commit message to be used when merging this PR e.g. docs: add architecture diagrams [99999] -->
## Commit message
-  chore: fix create_github_release script