### PR TITLE
[731] Prefer local credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,8 @@ The authenticate payload for authenticating a user is a JSON with the schema:
     "rpId": "your_backend",
     "allowCredentials": [],
     "userVerification": "preferred"
-  }
+  },
+  "preferImmediatelyAvailableCredentials": true
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -273,6 +273,11 @@ The authenticate payload for authenticating a user is a JSON with the schema:
     - **`preferred`** → The authenticator will attempt user verification if supported (e.g., biometric authentication). If not, it may still proceed without verification.
     - **`discouraged`** → User verification is not required. The credential can be used without any local authentication, making it more convenient but less secure.
 
+6. **preferImmediatelyAvailableCredentials**
+  - Tells the authorization controller to prefer credentials that are immediately available on the local device.
+    - **`false`** → When there are no available passkeys in the device, a QR will be shown as a cross-device sign-in alternative.
+    - **`true`** → The passkeys sign-in will fail before presenting the cross-device flow. The app will receive an error, but the user will not be forced onto the alternative flow.
+
 ## Building and Running Sample App <a name="building-and-running-sample-app"></a>
 
 #### Android

--- a/shared/src/commonMain/kotlin/com/twilio/passkeys/models/AuthenticatePasskeyRequest.kt
+++ b/shared/src/commonMain/kotlin/com/twilio/passkeys/models/AuthenticatePasskeyRequest.kt
@@ -24,7 +24,10 @@ import kotlinx.serialization.Serializable
  * @property publicKey The public key associated with the authentication request.
  */
 @Serializable
-data class AuthenticatePasskeyRequest(val publicKey: AuthenticatePasskeyRequestPublicKey)
+data class AuthenticatePasskeyRequest(
+  val publicKey: AuthenticatePasskeyRequestPublicKey,
+  val preferImmediatelyAvailableCredentials: Boolean = true
+)
 
 /**
  * Represents the public key information used for authenticating a passkey.

--- a/shared/src/commonMain/kotlin/com/twilio/passkeys/models/AuthenticatePasskeyRequest.kt
+++ b/shared/src/commonMain/kotlin/com/twilio/passkeys/models/AuthenticatePasskeyRequest.kt
@@ -26,7 +26,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class AuthenticatePasskeyRequest(
   val publicKey: AuthenticatePasskeyRequestPublicKey,
-  val preferImmediatelyAvailableCredentials: Boolean = true
+  val preferImmediatelyAvailableCredentials: Boolean = true,
 )
 
 /**

--- a/shared/src/iosMain/kotlin/com/twilio/passkeys/AuthorizationControllerWrapper.kt
+++ b/shared/src/iosMain/kotlin/com/twilio/passkeys/AuthorizationControllerWrapper.kt
@@ -34,6 +34,8 @@ interface IAuthorizationControllerWrapper {
  * @property deviceUtils The utility class for device-related operations.
  */
 class AuthorizationControllerWrapper : IAuthorizationControllerWrapper {
+  private val PREFER_IMMEDIATELY_AVAILABLE_CREDENTIALS: ULong = 1UL
+  private val NOT_PREFER_IMMEDIATELY_AVAILABLE_CREDENTIALS: ULong = 0UL
   private lateinit var authController: ASAuthorizationController
   private var createPasskeyCompletion: ((CreatePasskeyResult) -> Unit)? = null
   private var authenticatePasskeyCompletion: ((AuthenticatePasskeyResult) -> Unit)? = null
@@ -57,7 +59,9 @@ class AuthorizationControllerWrapper : IAuthorizationControllerWrapper {
     this.authenticatePasskeyCompletion = completion
     this.authController = authController
     this.authController.delegate = authenticatePasskeyDelegate
-    this.authController.performRequests()
+
+    val options = if (preferImmediatelyAvailableCredentials) PREFER_IMMEDIATELY_AVAILABLE_CREDENTIALS else NOT_PREFER_IMMEDIATELY_AVAILABLE_CREDENTIALS
+    this.authController.performRequestsWithOptions(options)
   }
 
   private val createPasskeyDelegate =

--- a/shared/src/iosMain/kotlin/com/twilio/passkeys/AuthorizationControllerWrapper.kt
+++ b/shared/src/iosMain/kotlin/com/twilio/passkeys/AuthorizationControllerWrapper.kt
@@ -8,7 +8,6 @@ import com.twilio.passkeys.utils.DeviceUtils
 import platform.AuthenticationServices.ASAuthorization
 import platform.AuthenticationServices.ASAuthorizationController
 import platform.AuthenticationServices.ASAuthorizationControllerDelegateProtocol
-import platform.AuthenticationServices.ASAuthorizationControllerRequestOptions
 import platform.AuthenticationServices.ASAuthorizationPlatformPublicKeyCredentialAssertion
 import platform.AuthenticationServices.ASAuthorizationPlatformPublicKeyCredentialRegistration
 import platform.AuthenticationServices.ASAuthorizationPublicKeyCredentialAttachment
@@ -34,8 +33,6 @@ interface IAuthorizationControllerWrapper {
  * @property deviceUtils The utility class for device-related operations.
  */
 class AuthorizationControllerWrapper : IAuthorizationControllerWrapper {
-  private val PREFER_IMMEDIATELY_AVAILABLE_CREDENTIALS: ULong = 1UL
-  private val NOT_PREFER_IMMEDIATELY_AVAILABLE_CREDENTIALS: ULong = 0UL
   private lateinit var authController: ASAuthorizationController
   private var createPasskeyCompletion: ((CreatePasskeyResult) -> Unit)? = null
   private var authenticatePasskeyCompletion: ((AuthenticatePasskeyResult) -> Unit)? = null
@@ -60,7 +57,9 @@ class AuthorizationControllerWrapper : IAuthorizationControllerWrapper {
     this.authController = authController
     this.authController.delegate = authenticatePasskeyDelegate
 
-    val options = if (preferImmediatelyAvailableCredentials) PREFER_IMMEDIATELY_AVAILABLE_CREDENTIALS else NOT_PREFER_IMMEDIATELY_AVAILABLE_CREDENTIALS
+    val options = if (preferImmediatelyAvailableCredentials)
+      PREFER_IMMEDIATELY_AVAILABLE_CREDENTIALS
+      else NOT_PREFER_IMMEDIATELY_AVAILABLE_CREDENTIALS
     this.authController.performRequestsWithOptions(options)
   }
 
@@ -165,5 +164,10 @@ class AuthorizationControllerWrapper : IAuthorizationControllerWrapper {
 
   private fun mapToTwilioException(error: NSError): TwilioException {
     return error.toTwilioException()
+  }
+
+  companion object {
+    const val PREFER_IMMEDIATELY_AVAILABLE_CREDENTIALS: ULong = 1UL
+    const val NOT_PREFER_IMMEDIATELY_AVAILABLE_CREDENTIALS: ULong = 0UL
   }
 }

--- a/shared/src/iosMain/kotlin/com/twilio/passkeys/AuthorizationControllerWrapper.kt
+++ b/shared/src/iosMain/kotlin/com/twilio/passkeys/AuthorizationControllerWrapper.kt
@@ -8,6 +8,7 @@ import com.twilio.passkeys.utils.DeviceUtils
 import platform.AuthenticationServices.ASAuthorization
 import platform.AuthenticationServices.ASAuthorizationController
 import platform.AuthenticationServices.ASAuthorizationControllerDelegateProtocol
+import platform.AuthenticationServices.ASAuthorizationControllerRequestOptions
 import platform.AuthenticationServices.ASAuthorizationPlatformPublicKeyCredentialAssertion
 import platform.AuthenticationServices.ASAuthorizationPlatformPublicKeyCredentialRegistration
 import platform.AuthenticationServices.ASAuthorizationPublicKeyCredentialAttachment
@@ -22,6 +23,7 @@ interface IAuthorizationControllerWrapper {
 
   fun authenticatePasskey(
     authController: ASAuthorizationController,
+    preferImmediatelyAvailableCredentials: Boolean,
     completion: (AuthenticatePasskeyResult) -> Unit,
   )
 }
@@ -49,6 +51,7 @@ class AuthorizationControllerWrapper : IAuthorizationControllerWrapper {
 
   override fun authenticatePasskey(
     authController: ASAuthorizationController,
+    preferImmediatelyAvailableCredentials: Boolean,
     completion: (AuthenticatePasskeyResult) -> Unit,
   ) {
     this.authenticatePasskeyCompletion = completion

--- a/shared/src/iosMain/kotlin/com/twilio/passkeys/AuthorizationControllerWrapper.kt
+++ b/shared/src/iosMain/kotlin/com/twilio/passkeys/AuthorizationControllerWrapper.kt
@@ -57,9 +57,8 @@ class AuthorizationControllerWrapper : IAuthorizationControllerWrapper {
     this.authController = authController
     this.authController.delegate = authenticatePasskeyDelegate
 
-    val options = if (preferImmediatelyAvailableCredentials)
-      PREFER_IMMEDIATELY_AVAILABLE_CREDENTIALS
-      else NOT_PREFER_IMMEDIATELY_AVAILABLE_CREDENTIALS
+    val options =
+      if (preferImmediatelyAvailableCredentials) PREFER_IMMEDIATELY_AVAILABLE_CREDENTIALS else NOT_PREFER_IMMEDIATELY_AVAILABLE_CREDENTIALS
     this.authController.performRequestsWithOptions(options)
   }
 

--- a/shared/src/iosMain/kotlin/com/twilio/passkeys/TwilioPasskeys.kt
+++ b/shared/src/iosMain/kotlin/com/twilio/passkeys/TwilioPasskeys.kt
@@ -152,9 +152,11 @@ actual open class TwilioPasskeys internal constructor(
         ),
       )
 
-      authControllerWrapper.authenticatePasskey(authController = authController, preferImmediatelyAvailableCredentials = preferImmediatelyAvailableCredentials, completion = {
-        continuation.resume(it)
-      })
+      authControllerWrapper.authenticatePasskey(
+        authController = authController,
+        preferImmediatelyAvailableCredentials = preferImmediatelyAvailableCredentials,
+        completion = { continuation.resume(it) }
+      )
     }
 
   /**

--- a/shared/src/iosMain/kotlin/com/twilio/passkeys/TwilioPasskeys.kt
+++ b/shared/src/iosMain/kotlin/com/twilio/passkeys/TwilioPasskeys.kt
@@ -136,6 +136,7 @@ actual open class TwilioPasskeys internal constructor(
     appContext: AppContext,
   ): AuthenticatePasskeyResult =
     suspendCancellableCoroutine { continuation ->
+      val preferImmediatelyAvailableCredentials = authenticatePasskeyRequest.preferImmediatelyAvailableCredentials
       val publicKeyCredentialProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(authenticatePasskeyRequest.publicKey.rpId)
       val challenge = NSData.create(base64Encoding = authenticatePasskeyRequest.publicKey.challenge)
       val assertionRequest = publicKeyCredentialProvider.createCredentialAssertionRequestWithChallenge(challenge = challenge!!)

--- a/shared/src/iosMain/kotlin/com/twilio/passkeys/TwilioPasskeys.kt
+++ b/shared/src/iosMain/kotlin/com/twilio/passkeys/TwilioPasskeys.kt
@@ -152,7 +152,7 @@ actual open class TwilioPasskeys internal constructor(
         ),
       )
 
-      authControllerWrapper.authenticatePasskey(authController = authController, completion = {
+      authControllerWrapper.authenticatePasskey(authController = authController, preferImmediatelyAvailableCredentials = preferImmediatelyAvailableCredentials, completion = {
         continuation.resume(it)
       })
     }

--- a/shared/src/iosMain/kotlin/com/twilio/passkeys/TwilioPasskeys.kt
+++ b/shared/src/iosMain/kotlin/com/twilio/passkeys/TwilioPasskeys.kt
@@ -155,7 +155,7 @@ actual open class TwilioPasskeys internal constructor(
       authControllerWrapper.authenticatePasskey(
         authController = authController,
         preferImmediatelyAvailableCredentials = preferImmediatelyAvailableCredentials,
-        completion = { continuation.resume(it) }
+        completion = { continuation.resume(it) },
       )
     }
 

--- a/shared/src/iosTest/kotlin/com/twilio/passkeys/mocks/AuthorizationControllerWrapperMock.kt
+++ b/shared/src/iosTest/kotlin/com/twilio/passkeys/mocks/AuthorizationControllerWrapperMock.kt
@@ -24,6 +24,7 @@ class AuthorizationControllerWrapperMock : IAuthorizationControllerWrapper {
 
   override fun authenticatePasskey(
     authController: ASAuthorizationController,
+    preferImmediatelyAvailableCredentials: Boolean,
     completion: (AuthenticatePasskeyResult) -> Unit,
   ) {
     authenticatePasskeyResultValue?.let {


### PR DESCRIPTION
<!-- Thanks for contributing to Twilio Verify Passkeys. Please consider this template for your PR -->
<!-- Title format: [Ticket Number] - Brief description -->
<!-- Assignee: Please assign yourself to this PR -->
<!-- Labels: Please add proper labels accordingly (task, bug, housekeeping, etc) -->

<!-- Ticket: Please add the ticket number or the Github issue number according to your case -->
## Ticket
- [731]

<!-- Description: Please add a detailed description of your contribution. Include associated PRs or dependencies. If you're opening an integration PR, please add proper checklist of remaining items and tag this PR with a "DO NOT MERGE YET" -->
## Description
- Add the option `preferimmediatelyavailablecredentials`  to prevent showing the cross-device flow (showing QR) for passkeys sign-in (authenticate).

<!-- Commit message: This repository uses a commit message convention https://www.conventionalcommits.org/en/v1.0.0/ set the commit message to be used when merging this PR e.g. docs: add architecture diagrams [99999] -->
## Commit message
- feat: option to prefer immediately available credentials

<!-- Testing: Please check all that apply -->
## Testing
- [ ] Added unit tests
- [ ] Ran unit tests successfully
- [ ] Added documentation for public APIs and/or Wiki
